### PR TITLE
Update to RestEASY 3.1.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
 
-    <resteasy.version>3.0.20.Final</resteasy.version>
+    <resteasy.version>3.1.3.Final</resteasy.version>
     <jackson2.version>2.8.2</jackson2.version>
 
     <repoHost>https://otto.takari.io</repoHost>
@@ -216,6 +216,12 @@
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-client</artifactId>
         <version>${resteasy.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/siesta-server/src/main/java/org/sonatype/siesta/server/internal/resteasy/SisuResteasyProviderFactory.java
+++ b/siesta-server/src/main/java/org/sonatype/siesta/server/internal/resteasy/SisuResteasyProviderFactory.java
@@ -28,7 +28,6 @@ import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.ParamConverterProvider;
 
-import org.jboss.resteasy.client.exception.mapper.ClientExceptionMapper;
 import org.jboss.resteasy.core.MediaTypeMap;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 import org.jboss.resteasy.spi.StringConverter;
@@ -48,9 +47,7 @@ public class SisuResteasyProviderFactory
   private static final Logger log = LoggerFactory.getLogger(SisuResteasyProviderFactory.class);
 
   /**
-   * Unregisters a @Provider type from this factory.
-   *
-   * @param provider type
+   * Unregister a @Provider type from this factory.
    */
   public void removeRegistrations(Class<?> type) {
     log.debug("Removing registrations for: {}", type.getName());
@@ -86,9 +83,6 @@ public class SisuResteasyProviderFactory
     }
     else if (ParamConverterProvider.class.isAssignableFrom(type)) {
       removeInstancesOf(type, paramConverterProviders);
-    }
-    else if (ClientExceptionMapper.class.isAssignableFrom(type)) {
-      removeInstancesOf(type, clientExceptionMappers.values());
     }
     else if (StringConverter.class.isAssignableFrom(type)) {
       removeInstancesOf(type, stringConverters.values());


### PR DESCRIPTION
Some minor adjustments needed for the deployment lifecycle for RestEASY to detect the global components required.

Though could be simpler perhaps by forcing the "resteasy.servlet.context.deployment=false" init-param, but unsure what wrinkles that may have.