### PR TITLE
Allow initialization using preset TCCL

### DIFF
--- a/siesta-server/src/main/java/org/sonatype/siesta/server/SiestaServlet.java
+++ b/siesta-server/src/main/java/org/sonatype/siesta/server/SiestaServlet.java
@@ -50,6 +50,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class SiestaServlet
     extends HttpServlet
 {
+  public static final String ATTR_PRESET_TCCL = SiestaServlet.class.getName() + ".presetContextClassloader";
+  
   private final Logger log = LoggerFactory.getLogger(getClass());
 
   private final BeanLocator beanLocator;

--- a/siesta-server/src/main/java/org/sonatype/siesta/server/internal/resteasy/ComponentContainerImpl.java
+++ b/siesta-server/src/main/java/org/sonatype/siesta/server/internal/resteasy/ComponentContainerImpl.java
@@ -24,7 +24,7 @@ import javax.ws.rs.ext.RuntimeDelegate;
 
 import org.sonatype.siesta.Resource;
 import org.sonatype.siesta.server.ComponentContainer;
-
+import org.sonatype.siesta.server.SiestaServlet;
 import org.eclipse.sisu.BeanEntry;
 import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
 import org.jboss.resteasy.spi.ResteasyDeployment;
@@ -52,6 +52,11 @@ public class ComponentContainerImpl
 
   @Override
   public void init(final ServletConfig servletConfig) throws ServletException {
+    if (isPresetTccl(servletConfig)) {
+      doInit(servletConfig);
+      return;
+    }
+
     final ClassLoader cl = Thread.currentThread().getContextClassLoader();
     try {
       Thread.currentThread().setContextClassLoader(ResteasyProviderFactory.class.getClassLoader());
@@ -60,6 +65,11 @@ public class ComponentContainerImpl
     finally {
       Thread.currentThread().setContextClassLoader(cl);
     }
+  }
+
+  private boolean isPresetTccl(final ServletConfig servletConfig) {
+    Object presetTccl = servletConfig.getServletContext().getAttribute(SiestaServlet.ATTR_PRESET_TCCL);
+    return presetTccl != null && (presetTccl == Boolean.TRUE || Boolean.parseBoolean(presetTccl.toString()));
   }
 
   private void doInit(final ServletConfig servletConfig) throws ServletException {


### PR DESCRIPTION
Setting classloader that loaded resteasy as tccl does not allow picking Providers up the classloader hierarchy chain.
One example is jenkins, where one plugin (with its own classloader) loaded siesta and resteasy runtime, but other plugins wish to provide extensions to it. All plugin classloaders share a common 'uberClassLoader', which can be pre-set as tccl prior to siesta initialization.